### PR TITLE
Fixed issues when trying to recreate a previously delete folder.

### DIFF
--- a/lib/BrickMapMixin.js
+++ b/lib/BrickMapMixin.js
@@ -441,6 +441,15 @@ const BrickMapMixin = {
             }
 
             if (typeof parentDir.items[dirName] !== 'undefined' && options.trailingNodeType === "parent") {
+                const currentNode = parentDir.items[dirName];
+                if(this.nodeIsDeleted(currentNode)) {
+                    // trying to create an already deleted node
+                    // so we need remove the "deletedAt" timestamp
+                    delete currentNode.metadata.deletedAt;
+                    this.updateTimeMetadata(currentNode, "createdAt");
+                    return;
+                }
+
                 throw new Error('Unable to create folder. A file or folder already exists in that location.');
             }
         }


### PR DESCRIPTION
opendsu test that reproduces the issues, before the fix:

```
require("../../../../../psknode/bundles/testsRuntime");
const { launchApiHubTestNode } = require("../../../../../psknode/tests/util/tir");

const dc = require("double-check");
const assert = dc.assert;
const opendsu = require("opendsu");
const resolver = opendsu.loadAPI("resolver");
const keySSIApi = opendsu.loadAPI("keyssi");
const DOMAIN = "default";

assert.callback(
    "DSU folder issues test",
    async (testFinished) => {
        const testFolder = await $$.promisify(dc.createTestFolder)("DSUFolderIssuesTest");
        const port = await $$.promisify(launchApiHubTestNode)(10, testFolder);

        const templateSeedSSI = keySSIApi.createTemplateSeedSSI(DOMAIN);

        const createStandardDSU = async() => {
            const standardDSU = await $$.promisify(resolver.createDSU)(templateSeedSSI);
            return standardDSU;
        }
    

        const standardDSU = await createStandardDSU();

        const folderPath = "/demo/demo1";

        await $$.promisify(standardDSU.createFolder)("/demo");

        console.log(`Creating folder ${folderPath}...`);
        await $$.promisify(standardDSU.createFolder)(folderPath);

        await $$.promisify(standardDSU.writeFile)("/demo/demo1/demo.txt", "");
        
        console.log(`Removing folder ${folderPath}...`);
        await $$.promisify(standardDSU.delete)(folderPath);

        console.log(`Creating folder ${folderPath}...`);
        // failed before the fixed with error: 
        // Error: Unable to create folder. A file or folder already exists in that location.
        await $$.promisify(standardDSU.createFolder)(folderPath);

        testFinished();
    },
    50000
);

```